### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,14 +10,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 16, 17 ]
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 16
+    - name: set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2.3.1
       with:
-        java-version: '16'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }}
+        distribution: 'zulu'
         cache: gradle
 
     - name: Grant execute permission for gradlew


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK including archived and non-LTS releases.